### PR TITLE
Improve search box functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,12 +89,13 @@
           </div>
         </div>
         <div class="search">
-          <form action="https://search.brave.com/search/">
-            <label for="q" autofocus>> find / </label>
+          <form onsubmit="return search()">
+            <label for="search_box" autofocus>> find / </label>
             <input
               type="text"
               placeholder="Type Here"
-              name="q"
+              name="search_box"
+              id="search_box"
               autocomplete="off"
               autofocus
             />
@@ -138,5 +139,26 @@
       var img_bar = document.getElementById("img");
       img_bar.src = `./main-themes/${cssFile}/images/gif.gif`;
     }
+
+    const search_url = "https://duckduckgo.com/";
+
+    function search() {
+      const is_url = /^(((http)|(https)):\/\/)?(www\.)?[a-zA-Z0-9]+\.[a-zA-Z]+\/?([a-zA-Z0-9/?=&%-_]+)?$/;
+      const is_ip = /^(((http)|(https)):\/\/)?([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}|localhost)(:[0-9]{1,5})?(\/[a-zA-Z0-9/?=&%-_]+)?$/;
+
+      const search_term = document.getElementById("search_box").value;
+      const url_match = search_term.match(is_url);
+      const ip_match = search_term.match(is_ip);
+      if (url_match != null) {
+        window.location.href = url_match[0].substring(0, 4) == "http" ? url_match[0] : "https://" + url_match[0];
+      } else if (ip_match != null) {
+        window.location.href = ip_match[0].substring(0, 4) == "http" ? ip_match[0] : "http://" + ip_match[0];
+      } else {
+        window.location.href = search_url + encodeURIComponent(search_term);
+      }
+
+      return false;
+    }
+
   </script>
 </html>

--- a/index.html
+++ b/index.html
@@ -156,8 +156,6 @@
       } else {
         window.location.href = search_url + encodeURIComponent(search_term);
       }
-
-      return false;
     }
 
   </script>

--- a/index.html
+++ b/index.html
@@ -156,6 +156,8 @@
       } else {
         window.location.href = search_url + encodeURIComponent(search_term);
       }
+
+      return false;
     }
 
   </script>

--- a/template-theme/mesh/index.html
+++ b/template-theme/mesh/index.html
@@ -92,6 +92,8 @@
       } else {
         window.location.href = search_url + encodeURIComponent(search_term);
       }
+
+      return false;
     }
   </script>
 </html>

--- a/template-theme/mesh/index.html
+++ b/template-theme/mesh/index.html
@@ -92,8 +92,6 @@
       } else {
         window.location.href = search_url + encodeURIComponent(search_term);
       }
-
-      return false;
     }
   </script>
 </html>

--- a/template-theme/mesh/index.html
+++ b/template-theme/mesh/index.html
@@ -60,12 +60,13 @@
           </div>
         </div>
         <div class="search">
-          <form action="https://search.brave.com/search/">
-            <label for="q" autofocus>> find / </label>
+          <form onsubmit="return search()">
+            <label for="search_box" autofocus>> find / </label>
             <input
               type="text"
               placeholder="Type Here"
-              name="q"
+              name="search_box"
+              id="search_box"
               autocomplete="off"
               autofocus
             />
@@ -74,4 +75,25 @@
       </div>
     </div>
   </body>
+  <script>
+    const search_url = "https://duckduckgo.com/";
+
+    function search() {
+      const is_url = /^(((http)|(https)):\/\/)?(www\.)?[a-zA-Z0-9]+\.[a-zA-Z]+\/?([a-zA-Z0-9/?=&%-_]+)?$/;
+      const is_ip = /^(((http)|(https)):\/\/)?([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}|localhost)(:[0-9]{1,5})?(\/[a-zA-Z0-9/?=&%-_]+)?$/;
+
+      const search_term = document.getElementById("search_box").value;
+      const url_match = search_term.match(is_url);
+      const ip_match = search_term.match(is_ip);
+      if (url_match != null) {
+        window.location.href = url_match[0].substring(0, 4) == "http" ? url_match[0] : "https://" + url_match[0];
+      } else if (ip_match != null) {
+        window.location.href = ip_match[0].substring(0, 4) == "http" ? ip_match[0] : "http://" + ip_match[0];
+      } else {
+        window.location.href = search_url + encodeURIComponent(search_term);
+      }
+
+      return false;
+    }
+  </script>
 </html>

--- a/template-theme/normal/index.html
+++ b/template-theme/normal/index.html
@@ -92,6 +92,8 @@
       } else {
         window.location.href = search_url + encodeURIComponent(search_term);
       }
+
+      return false;
     }
   </script>
 </html>

--- a/template-theme/normal/index.html
+++ b/template-theme/normal/index.html
@@ -92,8 +92,6 @@
       } else {
         window.location.href = search_url + encodeURIComponent(search_term);
       }
-
-      return false;
     }
   </script>
 </html>

--- a/template-theme/normal/index.html
+++ b/template-theme/normal/index.html
@@ -60,12 +60,13 @@
           </div>
         </div>
         <div class="search">
-          <form action="https://search.brave.com/search/">
-            <label for="q" autofocus>> find / </label>
+          <form onsubmit="return search()">
+            <label for="search_box" autofocus>> find / </label>
             <input
               type="text"
               placeholder="Type Here"
-              name="q"
+              name="search_box"
+              id="search_box"
               autocomplete="off"
               autofocus
             />
@@ -74,4 +75,25 @@
       </div>
     </div>
   </body>
+  <script>
+    const search_url = "https://duckduckgo.com/";
+
+    function search() {
+      const is_url = /^(((http)|(https)):\/\/)?(www\.)?[a-zA-Z0-9]+\.[a-zA-Z]+\/?([a-zA-Z0-9/?=&%-_]+)?$/;
+      const is_ip = /^(((http)|(https)):\/\/)?([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}|localhost)(:[0-9]{1,5})?(\/[a-zA-Z0-9/?=&%-_]+)?$/;
+
+      const search_term = document.getElementById("search_box").value;
+      const url_match = search_term.match(is_url);
+      const ip_match = search_term.match(is_ip);
+      if (url_match != null) {
+        window.location.href = url_match[0].substring(0, 4) == "http" ? url_match[0] : "https://" + url_match[0];
+      } else if (ip_match != null) {
+        window.location.href = ip_match[0].substring(0, 4) == "http" ? ip_match[0] : "http://" + ip_match[0];
+      } else {
+        window.location.href = search_url + encodeURIComponent(search_term);
+      }
+
+      return false;
+    }
+  </script>
 </html>


### PR DESCRIPTION
Hi everyone,
I've recently switched to using this startpage in my daily-driver setup since I really love the design. However I was used from an earlier startpage I made that I could as well perform searches as well as directly enter URLs on my startpage, and wanted to give something back to the community instead of keeping the changes to myself.
For now I only changed the templates, I don't really know how the generation of all the other variants is being handled.

The code I use uses two regexes to look if the entered query either matches a URL or an IP, and if so, redirects to the entered address. Otherwise it redirects normally to a search engine.

PS: I am no js-Developer, so I'm really welcoming any improvements to the code or regex used to match IPs and URLs.